### PR TITLE
Fix URL Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Next.js App Router + React Server Components
 
-Try the demo live here: [**https://next-news.vercel.app**](https://https://next-news.vercel.app).
+Try the demo live here: [**https://next-news.vercel.app**](https://next-news.vercel.app).
 
 ## Introduction
 


### PR DESCRIPTION
Corrected the incorrect URL in the README.md file from `https://https://next-news.vercel.app` to `https://next-news.vercel.app`. This ensures that users are directed to the correct website without encountering a broken link.